### PR TITLE
Prevent calculation engine from mutating the given dictionary.

### DIFF
--- a/Adletec.Sonic.Tests/CalculationEngineTests.cs
+++ b/Adletec.Sonic.Tests/CalculationEngineTests.cs
@@ -1279,9 +1279,52 @@ public class CalculationEngineTests
         double result = engine.Calculate("test(2, 3)");
         Assert.AreEqual(5.0, result);
     }
+
+    [TestMethod]
+    public void TestRerunCalculation()
+    {
+        const string expression = "var1 + var2 * var3 / 2";
+        var values = new Dictionary<string, double>
+        {
+            { "var1", 1 },
+            { "var2", 2 },
+            { "var3", 3 }
+        };
+        
+        var engine = new CalculationEngine(Options.CompiledCaseSensitive);
+        for (var i = 0; i < 3; i++)
+        {
+            engine.Calculate(expression, values);
+        }
+        // assert "does not throw an exception"
+        Assert.IsTrue(true);
+    }
+
+    [TestMethod]
+    public void TestRerunCalculationFunc()
+    {
+        const string expression = "var1 + var2 * var3 / 2";
+        var values = new Dictionary<string, double>
+        {
+            { "var1", 1 },
+            { "var2", 2 },
+            { "var3", 3 }
+        };
+        
+        var engine = new CalculationEngine(Options.CompiledCaseSensitive);
+        var func = engine.Build(expression);
+        for (var i = 0; i < 3; i++)
+        {
+            func(values);
+        }
+        // assert "does not throw an exception"
+        Assert.IsTrue(true);
+        
+    }
+    
 }
 
-static class Options
+internal static class Options
 {
     public static readonly SonicOptions CompiledNoOptimizer = new()
     {

--- a/Adletec.Sonic/CalculationEngine.cs
+++ b/Adletec.Sonic/CalculationEngine.cs
@@ -112,10 +112,9 @@ namespace Adletec.Sonic
             if (variables == null)
                 throw new ArgumentNullException(nameof(variables));
 
-            if (!caseSensitive)
-            {
-                variables = EngineUtil.ConvertVariableNamesToLowerCase(variables);
-            }
+            // We're writing to that dictionary so let's create a copy.
+            variables = !caseSensitive ? EngineUtil.ConvertVariableNamesToLowerCase(variables) : new Dictionary<string, double>(variables);
+            
             VerifyVariableNames(variables);
 
             // Add the reserved variables to the dictionary

--- a/Adletec.Sonic/Execution/FormulaBuilder.cs
+++ b/Adletec.Sonic/Execution/FormulaBuilder.cs
@@ -112,10 +112,10 @@ namespace Adletec.Sonic.Execution
             var formula = engine.Build(formulaText, constants);
 
             var adapter = new FuncAdapter();
-            return adapter.Wrap(parameters, variables => {
-
-                if(!caseSensitive)
-                    variables = EngineUtil.ConvertVariableNamesToLowerCase(variables);
+            return adapter.Wrap(parameters, variables =>
+            {
+                // We're writing to that dictionary so let's create a copy.
+                variables = !caseSensitive ? EngineUtil.ConvertVariableNamesToLowerCase(variables) : new Dictionary<string, double>(variables);
 
                 engine.VerifyVariableNames(variables);
 


### PR DESCRIPTION
Fixes bug that handing the same dictionary to the Calculate method twice throws an hard to comprehend exception.