### PR TITLE
Minor Clean-Up

### DIFF
--- a/Adletec.Sonic.Tests/CalculationEngineTests.cs
+++ b/Adletec.Sonic.Tests/CalculationEngineTests.cs
@@ -555,13 +555,17 @@ public class CalculationEngineTests
     }
 
     [TestMethod]
-    public void TestReservedVariableName()
+    public void TestReservedVariableNameCaseInsensitiveGuarded()
     {
         AssertExtensions.ThrowsException<ArgumentException>(() =>
         {
             var variables = new Dictionary<string, double> { { "pi", 2.0 } };
 
-            var engine = CalculationEngine.CreateWithDefaults();
+            var engine = CalculationEngine.Create()
+                .DisableCaseSensitivity()
+                .EnableGuardedMode()
+                .Build();
+            
             double result = engine.Evaluate("2 * pI", variables);
         });
     }
@@ -1255,11 +1259,23 @@ public class CalculationEngineTests
     }
 
     [TestMethod]
-    public void TestConflictingConstantAndVariableCompiled()
+    public void TestConflictingConstantAndVariableUnguardedCompiled()
+    {
+            var engine = SonicBuilders.Compiled()
+                .AddConstant("a", 1)
+                .Build();
+
+            var result = engine.Evaluate("a+a", new Dictionary<string, double> { { "a", 2 } });
+            Assert.AreEqual(2.0, result);
+    }
+    
+    [TestMethod]
+    public void TestConflictingConstantAndVariableGuardedCompiled()
     {
         AssertExtensions.ThrowsException<ArgumentException>(() =>
         {
             var engine = SonicBuilders.Compiled()
+                .EnableGuardedMode()
                 .AddConstant("a", 1)
                 .Build();
 
@@ -1331,11 +1347,23 @@ public class CalculationEngineTests
     }
 
     [TestMethod]
-    public void TestConflictingConstantAndVariableInterpreted()
+    public void TestConflictingConstantAndVariableUnguardedInterpreted()
+    {
+            var engine = SonicBuilders.Interpreted()
+                .AddConstant("a", 1)
+                .Build();
+
+            var result = engine.Evaluate("a+a", new Dictionary<string, double> { { "a", 2 } });
+            Assert.AreEqual(2.0, result);
+    }
+
+    [TestMethod]
+    public void TestConflictingConstantAndVariableGuardedInterpreted()
     {
         AssertExtensions.ThrowsException<ArgumentException>(() =>
         {
             var engine = SonicBuilders.Interpreted()
+                .EnableGuardedMode()
                 .AddConstant("a", 1)
                 .Build();
 

--- a/Adletec.Sonic/CalculationEngine.cs
+++ b/Adletec.Sonic/CalculationEngine.cs
@@ -129,13 +129,8 @@ namespace Adletec.Sonic
             if (variables == null)
                 throw new ArgumentNullException(nameof(variables));
 
-            // We're writing to that dictionary so let's create a copy.
-            variables = !caseSensitive ? EngineUtil.ConvertVariableNamesToLowerCase(variables) : new Dictionary<string, double>(variables);
+            variables = !caseSensitive ? EngineUtil.ConvertVariableNamesToLowerCase(variables) : variables;
             
-            // Add the reserved variables to the dictionary
-            foreach (ConstantInfo constant in ConstantRegistry)
-                variables.Add(constant.ConstantName, constant.Value);
-
             if (IsInFormulaCache(expression, out var function))
             {
                 return function(variables);

--- a/Adletec.Sonic/CalculationEngine.cs
+++ b/Adletec.Sonic/CalculationEngine.cs
@@ -129,8 +129,6 @@ namespace Adletec.Sonic
             if (variables == null)
                 throw new ArgumentNullException(nameof(variables));
 
-            variables = !caseSensitive ? EngineUtil.ConvertVariableNamesToLowerCase(variables) : variables;
-            
             if (IsInFormulaCache(expression, out var function))
             {
                 return function(variables);


### PR DESCRIPTION
* Removes two unnecessary operations from the evaluation path.
* Fixes test issues masked by those (erroneous) operations