### PR TITLE
Validation Improvements

### DIFF
--- a/Adletec.Sonic.Tests/ValidatorTest.cs
+++ b/Adletec.Sonic.Tests/ValidatorTest.cs
@@ -405,6 +405,15 @@ public class ValidatorTest
     }
     
     [TestMethod]
+    public void TestFunctionCallWithWhiteSpace()
+    {
+        ValidateExpression("ifless (0.57, (3000-500)/(1500-500), 10, 20)");
+        // does not throw
+        Assert.IsTrue(true);
+    }
+    
+    
+    [TestMethod]
     public void TestUnknownFunction()
     {
         try

--- a/Adletec.Sonic.Tests/ValidatorTest.cs
+++ b/Adletec.Sonic.Tests/ValidatorTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Linq.Expressions;
 using Adletec.Sonic.Execution;
 using Adletec.Sonic.Parsing;
 using Adletec.Sonic.Parsing.Tokenizing;
@@ -30,14 +31,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestUnexpectedFloatingPointConstant()
     {
+        const string expression = "1 + 3 34.4";
         try
         {
-            ValidateExpression("1 + 3 34.4");
+            ValidateExpression(expression);
         }
         catch (InvalidTokenParseException e)
         {
             Assert.AreEqual("34.4", e.Token);
             Assert.AreEqual(6, e.TokenPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -47,14 +50,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestDoubleValue()
     {
+        const string expression = "1 a * (sin(cos(3)) + ifless(1,2,3,4))";
         try
         {
-            ValidateExpression("1 a * (sin(cos(3)) + ifless(1,2,3,4))");
+            ValidateExpression(expression);
         }
         catch (InvalidTokenParseException e)
         {
             Assert.AreEqual("a", e.Token);
             Assert.AreEqual(2, e.TokenPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -64,14 +69,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestArgumentSeparatorOutsideFunction()
     {
+        const string expression = "1, a * (sin(cos(3)) + ifless(1,2,3,4))";
         try
         {
-            ValidateExpression("1, a * (sin(cos(3)) + ifless(1,2,3,4))");
+            ValidateExpression(expression);
         }
         catch (InvalidTokenParseException e)
         {
             Assert.AreEqual(",", e.Token);
             Assert.AreEqual(1, e.TokenPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -81,14 +88,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestMissingArgument()
     {
+        const string expression = "1 + a * (sin(cos(3)) + ifless(1,2,3))";
         try
         {
-            ValidateExpression("1 + a * (sin(cos(3)) + ifless(1,2,3))");
+            ValidateExpression(expression);
         }
         catch (InvalidArgumentCountParseException e)
         {
             Assert.AreEqual("ifless", e.FunctionName);
             Assert.AreEqual(23, e.FunctionNamePosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -98,14 +107,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestTooManyArguments()
     {
+        const string expression = "1 + a * (sin(cos(3)) + ifless(1,2,3,4,5))";
         try
         {
-            ValidateExpression("1 + a * (sin(cos(3)) + ifless(1,2,3,4,5))");
+            ValidateExpression(expression);
         }
         catch (InvalidArgumentCountParseException e)
         {
             Assert.AreEqual("ifless", e.FunctionName);
             Assert.AreEqual(23, e.FunctionNamePosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -123,14 +134,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestStartWithOperator()
     {
+        const string expression = "* 1 + a * (sin(cos(3)) + ifless(1,2,3,4))";
         try
         {
-            ValidateExpression("* 1 + a * (sin(cos(3)) + ifless(1,2,3,4))");
+            ValidateExpression(expression);
         }
         catch (MissingOperandParseException e)
         {
             Assert.AreEqual("*", e.Operator);
             Assert.AreEqual(0, e.OperatorPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -140,14 +153,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestMissingOperatorArgument()
     {
+        const string expression = "1 + * (sin(cos(3)) + ifless(1,2,3,4))";
         try
         {
-            ValidateExpression("1 + * (sin(cos(3)) + ifless(1,2,3,4))");
+            ValidateExpression(expression);
         }
         catch (MissingOperandParseException e)
         {
             Assert.AreEqual("+", e.Operator);
             Assert.AreEqual(2, e.OperatorPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -157,14 +172,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestEmptyParentheses()
     {
+        const string expression = "1 + a * ()";
         try
         {
-            ValidateExpression("1 + a * ()");
+            ValidateExpression(expression);
         }
         catch (InvalidTokenParseException e)
         {
             Assert.AreEqual(")", e.Token);
             Assert.AreEqual(9, e.TokenPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -174,13 +191,15 @@ public class ValidatorTest
     [TestMethod]
     public void TestMissingLeftParenthesis()
     {
+        const string expression = "1 + a )";
         try
         {
-            ValidateExpression("1 + a )");
+            ValidateExpression(expression);
         }
         catch (MissingLeftParenthesisParseException e)
         {
             Assert.AreEqual(6, e.RightParenthesisPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -190,13 +209,15 @@ public class ValidatorTest
     [TestMethod]
     public void TestMissingRightParenthesis()
     {
+        const string expression = "1 + (a * 2";
         try
         {
-            ValidateExpression("1 + (a * 2");
+            ValidateExpression(expression);
         }
         catch (MissingRightParenthesisParseException e)
         {
             Assert.AreEqual(4, e.LeftParenthesisPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -214,14 +235,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestParameterlessFunctionWithParameter()
     {
+        const string expression = "1 + random(1)";
         try
         {
-            ValidateExpression("1 + random(1)");
+            ValidateExpression(expression);
         }
         catch (InvalidArgumentCountParseException e)
         {
             Assert.AreEqual("random", e.FunctionName);
             Assert.AreEqual(4, e.FunctionNamePosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -231,13 +254,15 @@ public class ValidatorTest
     [TestMethod]
     public void TestRightParenthesisAsFirstToken()
     {
+        const string expression = ")+1";
         try
         {
-            ValidateExpression(")+1");
+            ValidateExpression(expression);
         }
         catch (MissingLeftParenthesisParseException e)
         {
             Assert.AreEqual(0, e.RightParenthesisPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -247,13 +272,15 @@ public class ValidatorTest
     [TestMethod]
     public void TestRightParenthesisAfterFunctionName()
     {
+        const string expression = "sin)";
         try
         {
-            ValidateExpression("sin)");
+            ValidateExpression(expression);
         }
         catch (MissingLeftParenthesisParseException e)
         {
             Assert.AreEqual(3, e.RightParenthesisPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -263,14 +290,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestWrongPlaceOfArguments()
     {
+        const string expression = "a ifless(,b,c,d)";
         try
         {
-            ValidateExpression("a ifless(,b,c,d)");
+            ValidateExpression(expression);
         }
         catch (InvalidTokenParseException e)
         {
             Assert.AreEqual("ifless", e.Token);
             Assert.AreEqual(2, e.TokenPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -280,14 +309,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestWrongPlaceOfArgumentsEmpty()
     {
+        const string expression = "a sin()";
         try
         {
-            ValidateExpression("a sin()");
+            ValidateExpression(expression);
         }
         catch (InvalidTokenParseException e)
         {
             Assert.AreEqual("sin", e.Token);
             Assert.AreEqual(2, e.TokenPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -305,14 +336,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestInvalidNumberOfOperationArguments()
     {
+        const string expression = "a +";
         try
         {
-            ValidateExpression("a +");
+            ValidateExpression(expression);
         }
         catch (MissingOperandParseException e)
         {
             Assert.AreEqual("+", e.Operator);
             Assert.AreEqual(2, e.OperatorPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -322,14 +355,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestDoubleOperators()
     {
+        const string expression = "1 2 3 + +";
         try
         {
-            ValidateExpression("1 2 3 + +");
+            ValidateExpression(expression);
         }
         catch (InvalidTokenParseException e)
         {
             Assert.AreEqual("2", e.Token);
             Assert.AreEqual(2, e.TokenPosition);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -339,14 +374,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestValidateInvalidToken()
     {
+        const string expression = "a ! b";
         try
         {
-            ValidateExpression("a ! b");
+            ValidateExpression(expression);
         }
         catch (InvalidTokenParseException e)
         {
             Assert.AreEqual(2, e.TokenPosition);
             Assert.AreEqual("!", e.Token);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -381,14 +418,16 @@ public class ValidatorTest
     public void TestDynamicFunctionsWithoutArgument()
     {
         
+        const string expression = "max()";
         try
         {
-            ValidateExpression("max()");
+            ValidateExpression(expression);
         }
         catch (InvalidArgumentCountParseException e)
         {
             Assert.AreEqual(0, e.FunctionNamePosition);
             Assert.AreEqual("max", e.FunctionName);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -416,14 +455,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestUnknownFunction()
     {
+        const string expression = "foo(bar)";
         try
         {
-            ValidateExpression("foo(bar)");
+            ValidateExpression(expression);
         }
         catch (UnknownFunctionParseException e)
         {
             Assert.AreEqual(0, e.FunctionNamePosition);
             Assert.AreEqual("foo", e.FunctionName);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -433,14 +474,16 @@ public class ValidatorTest
     [TestMethod]
     public void TestInvalidFloatingPointNumber()
     {
+        const string expression = "123.456.78";
         try
         {
-            ValidateExpression("123.456.78");
+            ValidateExpression(expression);
         }
         catch (InvalidFloatingPointNumberParseException e)
         {
             Assert.AreEqual(0, e.TokenPosition);
             Assert.AreEqual("123.456.78", e.Token);
+            Assert.AreEqual(expression, e.Expression);
             return;
         }
 
@@ -454,7 +497,7 @@ public class ValidatorTest
         var tokenParser = new TokenReader(CultureInfo.InvariantCulture, ',');
         var tokens = tokenParser.Read(expression);
         var validator = new Validator(functionRegistry, CultureInfo.InvariantCulture);
-        validator.Validate(tokens);
+        validator.Validate(tokens, expression);
     }
 
     private static FunctionRegistry GetPrefilledFunctionRegistry()

--- a/Adletec.Sonic.sln.DotSettings
+++ b/Adletec.Sonic.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Adletec/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Adletec.Sonic/Evaluator.cs
+++ b/Adletec.Sonic/Evaluator.cs
@@ -215,17 +215,17 @@ namespace Adletec.Sonic
         /// Build the abstract syntax tree for a given formula. The formula string will
         /// be first tokenized.
         /// </summary>
-        /// <param name="formulaText">A string containing the mathematical formula that must be converted 
-        /// into an abstract syntax tree.</param>
+        /// <param name="expression">A string containing the mathematical expression to be parsed.</param>
         /// <param name="compiledConstants">The constants which are to be available in the given formula.</param>
         /// <param name="optimize">If the abstract syntax tree should be optimized.</param>
-        /// <returns>The abstract syntax tree of the formula.</returns>
-        private Operation BuildAbstractSyntaxTree(string formulaText, IConstantRegistry compiledConstants, bool optimize, bool validate)
+        /// <param name="validate">If the expression should be checked for syntax errors.</param>
+        /// <returns>The abstract syntax tree of the expression.</returns>
+        private Operation BuildAbstractSyntaxTree(string expression, IConstantRegistry compiledConstants, bool optimize, bool validate)
         {
-            List<Token> tokens = tokenReader.Read(formulaText);
+            List<Token> tokens = tokenReader.Read(expression);
             if (validate)
             {
-                validator.Validate(tokens);
+                validator.Validate(tokens, expression);
             }
             
             var astBuilder = new AstBuilder(FunctionRegistry, compiledConstants);

--- a/Adletec.Sonic/ParseException.cs
+++ b/Adletec.Sonic/ParseException.cs
@@ -8,9 +8,12 @@ namespace Adletec.Sonic
     /// </summary>
     public class ParseException : Exception
     {
-        public ParseException(string message)
+        
+        public string Expression { get; }
+        public ParseException(string message, string expression)
             : base(message)
         {
+            Expression = expression;
         }
     }
 
@@ -24,8 +27,8 @@ namespace Adletec.Sonic
 
         public string Token { get; }
 
-        public InvalidTokenParseException(string message, int tokenPosition, string token) :
-            base(message)
+        public InvalidTokenParseException(string message, string expression, int tokenPosition, string token) :
+            base(message, expression)
         {
             TokenPosition = tokenPosition;
             Token = token;
@@ -40,8 +43,8 @@ namespace Adletec.Sonic
         public int TokenPosition { get; }
         public string Token { get; }
 
-        public InvalidFloatingPointNumberParseException(string message, int tokenPosition, string token) :
-            base(message)
+        public InvalidFloatingPointNumberParseException(string message, string expression, int tokenPosition, string token) :
+            base(message, expression)
         {
             TokenPosition = tokenPosition;
             Token = token;
@@ -55,7 +58,7 @@ namespace Adletec.Sonic
     {
         public int RightParenthesisPosition { get; }
 
-        public MissingLeftParenthesisParseException(string message, int rightParenthesisPosition) : base(message)
+        public MissingLeftParenthesisParseException(string message, string expression, int rightParenthesisPosition) : base(message, expression)
         {
             RightParenthesisPosition = rightParenthesisPosition;
         }
@@ -68,7 +71,7 @@ namespace Adletec.Sonic
     {
         public int LeftParenthesisPosition { get; }
 
-        public MissingRightParenthesisParseException(string message, int leftParenthesisPosition) : base(message)
+        public MissingRightParenthesisParseException(string message, string expression, int leftParenthesisPosition) : base(message, expression)
         {
             LeftParenthesisPosition = leftParenthesisPosition;
         }
@@ -82,8 +85,8 @@ namespace Adletec.Sonic
         public int FunctionNamePosition { get; }
         public string FunctionName { get; }
 
-        public UnknownFunctionParseException(string message, int functionNamePosition,
-            string functionName) : base(message)
+        public UnknownFunctionParseException(string message, string expression, int functionNamePosition,
+            string functionName) : base(message, expression)
         {
             FunctionNamePosition = functionNamePosition;
             FunctionName = functionName;
@@ -98,7 +101,7 @@ namespace Adletec.Sonic
         public int FunctionNamePosition { get; }
         public string FunctionName { get; }
 
-        public InvalidArgumentCountParseException(string message, int functionNamePosition, string functionName) : base(message)
+        public InvalidArgumentCountParseException(string message, string expression, int functionNamePosition, string functionName) : base(message, expression)
         {
             FunctionNamePosition = functionNamePosition;
             FunctionName = functionName;
@@ -113,8 +116,8 @@ namespace Adletec.Sonic
         public int OperatorPosition { get; }
         public string Operator { get; }
 
-        public MissingOperandParseException(string message, int operatorPosition, string @operator)
-            : base(message)
+        public MissingOperandParseException(string message, string expression, int operatorPosition, string @operator)
+            : base(message, expression)
         {
             OperatorPosition = operatorPosition;
             Operator = @operator;

--- a/Adletec.Sonic/Parsing/TokenReader.cs
+++ b/Adletec.Sonic/Parsing/TokenReader.cs
@@ -43,19 +43,19 @@ namespace Adletec.Sonic.Parsing
         }
 
         /// <summary>
-        /// Read in the provided formula and convert it into a list of tokens that can be processed by the
+        /// Read in the provided expression and convert it into a list of tokens that can be processed by the
         /// Abstract Syntax Tree Builder.
         /// </summary>
-        /// <param name="formula">The formula that must be converted into a list of tokens.</param>
-        /// <returns>The list of tokens for the provided formula.</returns>
-        public List<Token> Read(string formula)
+        /// <param name="expression">The expression to be converted into a list of tokens.</param>
+        /// <returns>The list of tokens for the provided expression.</returns>
+        public List<Token> Read(string expression)
         {
-            if (string.IsNullOrEmpty(formula))
-                throw new ArgumentNullException(nameof(formula));
+            if (string.IsNullOrEmpty(expression))
+                throw new ArgumentNullException(nameof(expression));
 
             var tokens = new List<Token>();
 
-            var characters = formula.ToCharArray();
+            var characters = expression.ToCharArray();
 
             var isFormulaSubPart = true;
             var isScientific = false;
@@ -78,7 +78,7 @@ namespace Adletec.Sonic.Parsing
                     while (++i < characters.Length && IsPartOfNumeric(characters[i], false, characters[i-1] == '-', isFormulaSubPart))
                     {
                         if (isScientific && IsScientificNotation(characters[i]))
-                            throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", i, characters[i].ToString());
+                            throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", expression, i, characters[i].ToString());
 
                         if (IsScientificNotation(characters[i]))
                         {
@@ -111,7 +111,7 @@ namespace Adletec.Sonic.Parsing
                         else
                         {
                             throw new InvalidFloatingPointNumberParseException($"Invalid floating point number: {buffer}",
-                                startPosition, buffer.ToString());
+                                expression, startPosition, buffer.ToString());
                         }
                     }
 
@@ -222,7 +222,7 @@ namespace Adletec.Sonic.Parsing
                                 isFormulaSubPart = false;
                             }
                             else
-                                throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", i, characters[i].ToString());
+                                throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", expression, i, characters[i].ToString());
                             break;
                         case '&':
                             if (i + 1 < characters.Length && characters[i + 1] == '&')
@@ -231,7 +231,7 @@ namespace Adletec.Sonic.Parsing
                                 isFormulaSubPart = false;
                             }
                             else
-                                throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", i, characters[i].ToString());
+                                throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", expression, i, characters[i].ToString());
                             break;
                         case '|':
                             if (i + 1 < characters.Length && characters[i + 1] == '|')
@@ -240,7 +240,7 @@ namespace Adletec.Sonic.Parsing
                                 isFormulaSubPart = false;
                             }
                             else
-                                throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", i, characters[i].ToString());
+                                throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", expression, i, characters[i].ToString());
                             break;
                         case '=':
                             if (i + 1 < characters.Length && characters[i + 1] == '=')
@@ -249,10 +249,10 @@ namespace Adletec.Sonic.Parsing
                                 isFormulaSubPart = false;
                             }
                             else
-                                throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", i, characters[i].ToString());
+                                throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", expression, i, characters[i].ToString());
                             break;
                         default:
-                            throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", i, characters[i].ToString());
+                            throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", expression, i, characters[i].ToString());
                     }
                 }
             }


### PR DESCRIPTION
* `TokenReader` now correctly identifies functions as such if there are white-spaces between the function name and the opening parenthesis.
* `ParseException` now contains the failed expression.