### PR TITLE
Feature/#39 validate variables

### DIFF
--- a/Adletec.Sonic.Tests/EvaluatorTests.cs
+++ b/Adletec.Sonic.Tests/EvaluatorTests.cs
@@ -1659,6 +1659,29 @@ public class EvaluatorTests
         var engine = SonicEngines.Interpreted();
         var result = engine.Evaluate("0 * a + 4 * 5");
     }
+
+    [TestMethod]
+    public void TestVariableValidationPass()
+    {
+        var engine = SonicEngines.Interpreted();
+        var expression = "a + b + c";
+        var variables = new List<string> { "a", "b", "c" };
+        engine.Validate(expression, variables);
+
+        // assert "does not throw an exception"
+        Assert.IsTrue(true);
+    }
+
+    [TestMethod]
+    public void TestVariableValidationFail()
+    {
+        var engine = SonicEngines.Interpreted();
+        var expression = "a + b + c";
+        var variables = new List<string> { "a", "b" };
+        Assert.ThrowsException<VariableNotDefinedException>(() =>
+            engine.Validate(expression, variables)
+        );
+    }
 }
 
 internal static class SonicEngines

--- a/Adletec.Sonic.Tests/EvaluatorTests.cs
+++ b/Adletec.Sonic.Tests/EvaluatorTests.cs
@@ -1652,6 +1652,13 @@ public class EvaluatorTests
                 .Build();
         });
     }
+
+    [TestMethod]
+    public void TestCalculateFoldedExpressionWithoutFoldedVariable()
+    {
+        var engine = SonicEngines.Interpreted();
+        var result = engine.Evaluate("0 * a + 4 * 5");
+    }
 }
 
 internal static class SonicEngines

--- a/Adletec.Sonic.Tests/ExpressionValidatorTest.cs
+++ b/Adletec.Sonic.Tests/ExpressionValidatorTest.cs
@@ -1,16 +1,14 @@
 using System;
 using System.Globalization;
 using System.Linq;
-using System.Linq.Expressions;
 using Adletec.Sonic.Execution;
 using Adletec.Sonic.Parsing;
-using Adletec.Sonic.Parsing.Tokenizing;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Adletec.Sonic.Tests;
 
 [TestClass]
-public class ValidatorTest
+public class ExpressionValidatorTest
 {
     [TestMethod]
     public void TestValidExpression()
@@ -512,7 +510,7 @@ public class ValidatorTest
         var functionRegistry = GetPrefilledFunctionRegistry();
         var tokenParser = new TokenReader(CultureInfo.InvariantCulture, ',');
         var tokens = tokenParser.Read(expression);
-        var validator = new Validator(functionRegistry, CultureInfo.InvariantCulture);
+        var validator = new ExpressionValidator(functionRegistry, CultureInfo.InvariantCulture);
         validator.Validate(tokens, expression);
     }
 

--- a/Adletec.Sonic.Tests/VariableValidatorTest.cs
+++ b/Adletec.Sonic.Tests/VariableValidatorTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Adletec.Sonic.Execution;
 using Adletec.Sonic.Operations;
@@ -87,10 +88,23 @@ public class VariableValidatorTest
         Assert.IsTrue(true);
     }
 
+    [TestMethod]
+    public void TestCompleteVariableDefinitionWithDifferentOperators()
+    {
+        var validator = new VariableValidator();
+        var variables = new List<string> { "x", "y", "z" };
+        var expression = "-constant + sin(x) + y / 4 * x - 12^z";
+        var ast = GetAst(expression, true);
+        validator.Validate(ast, variables);
+        // Assert doesn't throw
+        Assert.IsTrue(true);
+    }
+
     static Operation GetAst(string expression, bool optimize = false)
     {
         var tokenList = new TokenReader().Read(expression);
         var functionRegistry = new FunctionRegistry(true, false);
+        functionRegistry.RegisterFunction("sin", (Func<double, double>)Math.Sin);
         var constantRegistry = new ConstantRegistry(true, false);
         constantRegistry.RegisterConstant("constant", 1.0);
         var ast = new AstBuilder(functionRegistry, constantRegistry).Build(tokenList);

--- a/Adletec.Sonic.Tests/VariableValidatorTest.cs
+++ b/Adletec.Sonic.Tests/VariableValidatorTest.cs
@@ -9,8 +9,6 @@ namespace Adletec.Sonic.Tests;
 [TestClass]
 public class VariableValidatorTest
 {
-    // todo test with constants to make refactorings safer
-    
     [TestMethod]
     public void TestCompleteVariableDefinition()
     {
@@ -76,12 +74,25 @@ public class VariableValidatorTest
         // Assert doesn't throw
         Assert.Fail("Expected exception was not thrown.");
     }
+    
+    [TestMethod]
+    public void TestCompleteVariableDefinitionWithConstant()
+    {
+        var validator = new VariableValidator();
+        var variables = new List<string> { "x", "y" };
+        var expression = "constant + x + y";
+        var ast = GetAst(expression, true);
+        validator.Validate(ast, variables);
+        // Assert doesn't throw
+        Assert.IsTrue(true);
+    }
 
     static Operation GetAst(string expression, bool optimize = false)
     {
         var tokenList = new TokenReader().Read(expression);
         var functionRegistry = new FunctionRegistry(true, false);
         var constantRegistry = new ConstantRegistry(true, false);
+        constantRegistry.RegisterConstant("constant", 1.0);
         var ast = new AstBuilder(functionRegistry, constantRegistry).Build(tokenList);
         if (optimize)
         {

--- a/Adletec.Sonic.Tests/VariableValidatorTest.cs
+++ b/Adletec.Sonic.Tests/VariableValidatorTest.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using Adletec.Sonic.Execution;
+using Adletec.Sonic.Operations;
+using Adletec.Sonic.Parsing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Adletec.Sonic.Tests;
+
+[TestClass]
+public class VariableValidatorTest
+{
+    // todo test with constants to make refactorings safer
+    
+    [TestMethod]
+    public void TestCompleteVariableDefinition()
+    {
+        var validator = new VariableValidator();
+        var variables = new List<string> { "x", "y", "z" };
+        var expression = "x + y + z";
+        var ast = GetAst(expression);
+        validator.Validate(ast, variables);
+        // Assert doesn't throw
+        Assert.IsTrue(true);
+    }
+
+    [TestMethod]
+    public void TestIncompleteVariableDefinition()
+    {
+        var validator = new VariableValidator();
+        var variables = new List<string> { "x", "y" };
+        var expression = "x + y + z";
+        var ast = GetAst(expression);
+        try
+        {
+            validator.Validate(ast, variables);
+        }
+        catch (VariableNotDefinedException e)
+        {
+            Assert.AreEqual("Variable 'z' is not defined.", e.Message);
+            Assert.AreEqual("z", e.VariableName);
+            return;
+        }
+
+        Assert.Fail("Expected exception was not thrown.");
+    }
+
+    [TestMethod]
+    public void TestFoldedVariableDefinition()
+    {
+        var validator = new VariableValidator();
+        var variables = new List<string> { "x", "y" };
+        var expression = "x + y + 0 * z";
+        var ast = GetAst(expression, true);
+        validator.Validate(ast, variables);
+        // Assert doesn't throw
+        Assert.IsTrue(true);
+    }
+    
+    [TestMethod]
+    public void TestUnfoldedVariableDefinition()
+    {
+        var validator = new VariableValidator();
+        var variables = new List<string> { "x", "y" };
+        var expression = "x + y + 0 * z";
+        var ast = GetAst(expression);
+        try
+        {
+            validator.Validate(ast, variables);
+        }
+        catch (VariableNotDefinedException e)
+        {
+            Assert.AreEqual("Variable 'z' is not defined.", e.Message);
+            Assert.AreEqual("z", e.VariableName);
+            return;
+        }
+        // Assert doesn't throw
+        Assert.Fail("Expected exception was not thrown.");
+    }
+
+    static Operation GetAst(string expression, bool optimize = false)
+    {
+        var tokenList = new TokenReader().Read(expression);
+        var functionRegistry = new FunctionRegistry(true, false);
+        var constantRegistry = new ConstantRegistry(true, false);
+        var ast = new AstBuilder(functionRegistry, constantRegistry).Build(tokenList);
+        if (optimize)
+        {
+            ast = new Optimizer(new Interpreter(true, false)).Optimize(ast, functionRegistry, constantRegistry);
+        }
+
+        return ast;
+    }
+}

--- a/Adletec.Sonic/Evaluator.cs
+++ b/Adletec.Sonic/Evaluator.cs
@@ -18,6 +18,7 @@ namespace Adletec.Sonic
         private readonly Optimizer optimizer;
         private readonly IExecutor executor;
         private readonly ExpressionValidator expressionValidator;
+        private readonly VariableValidator variableValidator;
         
         private readonly MemoryCache<string, Func<IDictionary<string, double>, double>> executionFormulaCache;
         private readonly bool cacheEnabled;
@@ -120,6 +121,7 @@ namespace Adletec.Sonic
             }
             
             this.expressionValidator = new ExpressionValidator(FunctionRegistry, cultureInfo);
+            this.variableValidator = new VariableValidator();
         }
 
         internal IFunctionRegistry FunctionRegistry { get; }
@@ -156,12 +158,25 @@ namespace Adletec.Sonic
         }
 
         /// <summary>
-        /// Validates the given expression. If the expression is invalid, a matching subtype of ParseException is thrown.
+        /// Validates the given expression. If the expression is invalid, a matching subtype of <see cref="ParseException"/> is thrown.
         /// </summary>
         /// <param name="expression">The expression to check.</param>
         public void Validate(string expression)
         {
             BuildAbstractSyntaxTree(expression, ConstantRegistry, false, true);
+        }
+        
+        /// <summary>
+        /// Validates the given expression and checks if all necessary variables are defined. If the expression is invalid, a matching subtype of ParseException is thrown.
+        /// If the expression is invalid, a matching subtype of <see cref="ParseException"/> is thrown.
+        /// If a variable necessary for evaluation is not defined, a <see cref="VariableNotDefinedException"/> is thrown.
+        /// </summary>
+        /// <param name="expression">The expression to check.</param>
+        /// <param name="variables">The defined variable names.</param>
+        public void Validate(string expression, IList<string> variables)
+        {
+            var ast = BuildAbstractSyntaxTree(expression, ConstantRegistry, optimizerEnabled, true);
+            variableValidator.Validate(ast, variables);
         }
 
         private void RegisterDefaultFunctions()

--- a/Adletec.Sonic/Evaluator.cs
+++ b/Adletec.Sonic/Evaluator.cs
@@ -17,7 +17,7 @@ namespace Adletec.Sonic
         private readonly TokenReader tokenReader;
         private readonly Optimizer optimizer;
         private readonly IExecutor executor;
-        private readonly Validator validator;
+        private readonly ExpressionValidator expressionValidator;
         
         private readonly MemoryCache<string, Func<IDictionary<string, double>, double>> executionFormulaCache;
         private readonly bool cacheEnabled;
@@ -119,7 +119,7 @@ namespace Adletec.Sonic
                 }
             }
             
-            this.validator = new Validator(FunctionRegistry, cultureInfo);
+            this.expressionValidator = new ExpressionValidator(FunctionRegistry, cultureInfo);
         }
 
         internal IFunctionRegistry FunctionRegistry { get; }
@@ -225,7 +225,7 @@ namespace Adletec.Sonic
             List<Token> tokens = tokenReader.Read(expression);
             if (validate)
             {
-                validator.Validate(tokens, expression);
+                expressionValidator.Validate(tokens, expression);
             }
             
             var astBuilder = new AstBuilder(FunctionRegistry, compiledConstants);

--- a/Adletec.Sonic/IEvaluator.cs
+++ b/Adletec.Sonic/IEvaluator.cs
@@ -65,5 +65,30 @@ namespace Adletec.Sonic
         /// <exception cref="InvalidArgumentCountParseException">If a function call has the wrong number of arguments.</exception>
         /// <exception cref="MissingOperandParseException">If a binary operation is missing an operand.</exception>
         void Validate(string expression);
+
+        /// <summary>
+        /// Validates a given expression and checks if all variables necessary for evaluation are in the given variable list.
+        /// 
+        /// If the expression is invalid, the matching subtype of <see cref="ParseException"/> is thrown.
+        /// 
+        /// This includes:
+        ///  - Malformed numbers.
+        ///  - Unbalanced parentheses.
+        ///  - Unexpected tokens.
+        ///  - Unknown function names.
+        ///  - Wrong number of arguments for functions or operators.
+        /// 
+        /// </summary>
+        /// <param name="expression">The expression to be validated.</param>
+        /// <param name="variables">A list of variable names to check against.</param>
+        /// <exception cref="InvalidTokenParseException">If an invalid token is encountered.</exception>
+        /// <exception cref="InvalidFloatingPointNumberParseException">If a malformed floating point number is encountered.</exception>
+        /// <exception cref="MissingLeftParenthesisParseException">If parentheses are unbalanced (fewer left than right).</exception>
+        /// <exception cref="MissingRightParenthesisParseException">If parentheses are unbalanced (fewer right than left).</exception>
+        /// <exception cref="UnknownFunctionParseException">If an unknown function name is referenced.</exception>
+        /// <exception cref="InvalidArgumentCountParseException">If a function call has the wrong number of arguments.</exception>
+        /// <exception cref="MissingOperandParseException">If a binary operation is missing an operand.</exception>
+        /// <exception cref="VariableNotDefinedException">If a variable necessary for evaluation is missing.</exception>
+        void Validate(string expression, IList<string> variables);
     }
 }

--- a/Adletec.Sonic/Parsing/ExpressionValidator.cs
+++ b/Adletec.Sonic/Parsing/ExpressionValidator.cs
@@ -10,7 +10,7 @@ namespace Adletec.Sonic.Parsing
     /// <summary>
     /// A validator for the token list produced by the <see cref="TokenReader"/>.
     /// </summary>
-    public class Validator
+    public class ExpressionValidator
     {
         private readonly IFunctionRegistry functionRegistry;
         private readonly CultureInfo cultureInfo;
@@ -20,7 +20,7 @@ namespace Adletec.Sonic.Parsing
         /// </summary>
         /// <param name="functionRegistry">The function registry also used for evaluation.</param>
         /// <param name="cultureInfo">The culture info also used for evaluation.</param>
-        public Validator(IFunctionRegistry functionRegistry, CultureInfo cultureInfo)
+        public ExpressionValidator(IFunctionRegistry functionRegistry, CultureInfo cultureInfo)
         {
             this.functionRegistry = functionRegistry;
             this.cultureInfo = cultureInfo;

--- a/Adletec.Sonic/Parsing/VariableValidator.cs
+++ b/Adletec.Sonic/Parsing/VariableValidator.cs
@@ -3,6 +3,10 @@ using Adletec.Sonic.Operations;
 
 namespace Adletec.Sonic.Parsing
 {
+    /// <summary>
+    /// A validator for an AST as produced by the <see cref="AstBuilder"/>.
+    /// Checks if all variables referenced in the AST are defined.
+    /// </summary>
     public class VariableValidator
     {
         
@@ -14,37 +18,45 @@ namespace Adletec.Sonic.Parsing
         /// <exception cref="VariableNotDefinedException">If a referenced variable is not defined.</exception>
         public void Validate(Operation operation, IList<string> variables)
         {
-            if (operation.GetType() == typeof(Addition))
+            // traverse the AST recursively like we do in the optimizer;
+            // there are two possible termination conditions:
+            // - we reach a variable, which we check against the list of variables
+            // - we reach a constant, which we can safely ignore (no if-branch required)
+            //     => constants must be defined in order to be recognized as constants and like variables
+            //        can't contain further operations
+            
+            var operationType = operation.GetType();
+            if (operationType == typeof(Addition))
             {
                 var addition = (Addition)operation;
                 Validate(addition.Argument1, variables);
                 Validate(addition.Argument2, variables);
             }
-            else if (operation.GetType() == typeof(Subtraction))
+            else if (operationType == typeof(Subtraction))
             {
                 var subtraction = (Subtraction)operation;
                 Validate(subtraction.Argument1, variables);
                 Validate(subtraction.Argument2, variables);
             }
-            else if (operation.GetType() == typeof(Multiplication))
+            else if (operationType == typeof(Multiplication))
             {
                 var multiplication = (Multiplication)operation;
                 Validate(multiplication.Argument1, variables);
                 Validate(multiplication.Argument2, variables);
             }
-            else if (operation.GetType() == typeof(Division))
+            else if (operationType == typeof(Division))
             {
                 var division = (Division)operation;
                 Validate(division.Dividend, variables);
                 Validate(division.Divisor, variables);
             }
-            else if (operation.GetType() == typeof(Exponentiation))
+            else if (operationType == typeof(Exponentiation))
             {
                 var exponentiation = (Exponentiation)operation;
                 Validate(exponentiation.Base, variables);
                 Validate(exponentiation.Exponent, variables);
             }
-            else if (operation.GetType() == typeof(Variable))
+            else if (operationType == typeof(Variable))
             {
                 var variable = (Variable)operation;
                 if (variables.Contains(variable.Name) == false)
@@ -52,7 +64,7 @@ namespace Adletec.Sonic.Parsing
                     throw new VariableNotDefinedException($"Variable '{variable.Name}' is not defined.", variable.Name);
                 }
             }
-            else if (operation.GetType() == typeof(Function))
+            else if (operationType == typeof(Function))
             {
                 var function = (Function)operation;
                 foreach (var argument in function.Arguments)

--- a/Adletec.Sonic/Parsing/VariableValidator.cs
+++ b/Adletec.Sonic/Parsing/VariableValidator.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using Adletec.Sonic.Execution;
+using Adletec.Sonic.Operations;
+
+namespace Adletec.Sonic.Parsing
+{
+    public class VariableValidator
+    {
+        private readonly IConstantRegistry constantRegistry;
+
+        /// <summary>
+        /// Validate that all variables referenced in the given AST are defined.
+        /// </summary>
+        /// <param name="operation">The current root of the AST.</param>
+        /// <param name="variables">The list of variable names to check against.</param>
+        /// <exception cref="VariableNotDefinedException">If a referenced variable is not defined.</exception>
+        public void Validate(Operation operation, IList<string> variables)
+        {
+            if (operation.GetType() == typeof(Addition))
+            {
+                var addition = (Addition)operation;
+                Validate(addition.Argument1, variables);
+                Validate(addition.Argument2, variables);
+            }
+            else if (operation.GetType() == typeof(Subtraction))
+            {
+                var subtraction = (Subtraction)operation;
+                Validate(subtraction.Argument1, variables);
+                Validate(subtraction.Argument2, variables);
+            }
+            else if (operation.GetType() == typeof(Multiplication))
+            {
+                var multiplication = (Multiplication)operation;
+                Validate(multiplication.Argument1, variables);
+                Validate(multiplication.Argument2, variables);
+            }
+            else if (operation.GetType() == typeof(Division))
+            {
+                var division = (Division)operation;
+                Validate(division.Dividend, variables);
+                Validate(division.Divisor, variables);
+            }
+            else if (operation.GetType() == typeof(Exponentiation))
+            {
+                var exponentiation = (Exponentiation)operation;
+                Validate(exponentiation.Base, variables);
+                Validate(exponentiation.Exponent, variables);
+            }
+            else if (operation.GetType() == typeof(Variable))
+            {
+                var variable = (Variable)operation;
+                if (variables.Contains(variable.Name) == false)
+                {
+                    throw new VariableNotDefinedException($"Variable '{variable.Name}' is not defined.", variable.Name);
+                }
+            }
+            else if (operation.GetType() == typeof(Function))
+            {
+                var function = (Function)operation;
+                foreach (var argument in function.Arguments)
+                {
+                    Validate(argument, variables);
+                }
+            }
+        }
+    }
+}

--- a/Adletec.Sonic/Parsing/VariableValidator.cs
+++ b/Adletec.Sonic/Parsing/VariableValidator.cs
@@ -1,13 +1,11 @@
 using System.Collections.Generic;
-using Adletec.Sonic.Execution;
 using Adletec.Sonic.Operations;
 
 namespace Adletec.Sonic.Parsing
 {
     public class VariableValidator
     {
-        private readonly IConstantRegistry constantRegistry;
-
+        
         /// <summary>
         /// Validate that all variables referenced in the given AST are defined.
         /// </summary>

--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ By default, _sonic_ will validate the given expression upon evaluation (`Evaluat
 (`CreateDelegate()`-method). This means that _sonic_ will check if the given expression is syntactically correct and
 contains no unknown functions.
 
+If the expression contains a syntax error, _sonic_ will throw a `ParseException`. If the expression contains an unknown
+variable, _sonic_ will throw a `VariableNotDefinedException`.
+
 #### Validate an Expression
 If you want to validate an expression without evaluating it, you can use the `Validate()`-method of the `Evaluator`:
 
@@ -245,6 +248,33 @@ try {
   // handle exception
 }
 ```
+This will validate the **syntax of the expression** and throw a `ParseException` if the expression is invalid.
+
+#### Validate Variables
+If you also want to check variable completeness without evaluating the expression, you can use the `Validate(string expression, IList<string> variables)`-overload:
+  
+  ```csharp
+  var engine = Evaluator.CreateWithDefaults();
+  try {
+    engine.Validate("var1*var2", new List<string> { "var1", "var2" });
+  } catch (VariableNotDefinedException e) {
+    // handle exception
+  } catch (ParseException e) {
+    // handle exception
+  }
+  ```
+This will validate **the completeness of the variables** and **the syntax of the expression** and throw a `VariableNotDefinedException` if the expression contains an unknown variable or a `ParseException` if the expression is invalid.
+
+> **Note:** The decisive factor for variable completeness is not wether all variables referenced in the expression are defined, but wether all variables **necessary to evaluate the expression** are defined.
+> The optimizer, if enabled (default), will pre-evaluate parts of the expression which do not depend on variables, including multiplications with `0` or `0`-exponents.
+>
+> Consider the example `var1 + 0 * var2`.
+> If the optimizer is enabled, the expression will be pre-evaluated to `var1` and the expression will be valid even if `var2` is not defined. If the optimizer is disabled, the expression will be invalid if `var2` is not defined.
+> 
+> The Validate()-method will always behave like the Evaluate()-method in terms of the optimizer. If the optimizer is enabled, the expression will be pre-evaluated and the variables necessary to evaluate the expression will be checked. If the optimizer is disabled, the expression will be checked without pre-evaluation.
+>
+> However, the Validate()-method will **not** evaluate the expression, so it will be faster than the Evaluate()-method, if you don't need the result.
+
 
 #### Parse Exception Types
 The `Validate()`-method will throw a matching sub-type of [`ParseException`](https://github.com/adletec/sonic/blob/main/Adletec.Sonic/ParseException.cs) if the given expression is invalid.

--- a/README.md
+++ b/README.md
@@ -265,7 +265,8 @@ If you also want to check variable completeness without evaluating the expressio
   ```
 This will validate **the completeness of the variables** and **the syntax of the expression** and throw a `VariableNotDefinedException` if the expression contains an unknown variable or a `ParseException` if the expression is invalid.
 
-> **Note:** The decisive factor for variable completeness is not wether all variables referenced in the expression are defined, but wether all variables **necessary to evaluate the expression** are defined.
+> [!NOTE]
+> The decisive factor for variable completeness is not wether all variables referenced in the expression are defined, but wether all variables **necessary to evaluate the expression** are defined.
 > The optimizer, if enabled (default), will pre-evaluate parts of the expression which do not depend on variables, including multiplications with `0` or `0`-exponents.
 >
 > Consider the example `var1 + 0 * var2`.


### PR DESCRIPTION
Adds an overload of the `Validate`-method which will take variable-completeness into account, as proposed in #39.