### PR TITLE
Bugfix/#42 empty result stack

### DIFF
--- a/Adletec.Sonic.Tests/EvaluatorTests.cs
+++ b/Adletec.Sonic.Tests/EvaluatorTests.cs
@@ -1682,6 +1682,19 @@ public class EvaluatorTests
             engine.Validate(expression, variables)
         );
     }
+    
+    // Issue #42
+    [TestMethod]
+    public void TestStaticFuncInDynamicFunc()
+    {
+        var engine = SonicEngines.Interpreted();
+        var expression = "min(if(a==1, 2, 3))";
+        var variables = new List<string> { "a" };
+        engine.Validate(expression, variables);
+        
+        // assert "does not throw an exception"
+        Assert.IsTrue(true);
+    }
 }
 
 internal static class SonicEngines

--- a/Adletec.Sonic/Parsing/AstBuilder.cs
+++ b/Adletec.Sonic/Parsing/AstBuilder.cs
@@ -283,8 +283,9 @@ namespace Adletec.Sonic.Parsing
             var functionName = (string)functionToken.Value;
             FunctionInfo functionInfo = functionRegistry.GetFunctionInfo(functionName);
 
+            var dynamicFunctionArgumentCount = dynamicFunctionArgumentCountStack.Pop();
             int actualParameterCount = functionInfo.IsDynamicFunc
-                ? dynamicFunctionArgumentCountStack.Pop()
+                ? dynamicFunctionArgumentCount
                 : functionInfo.NumberOfParameters;
 
             var operations = new List<Operation>();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 1.4.1 (XXXX-XX-XX)
+### Summary
+
+### Bugfix
+- Fixes #42, in which nested functions could lead to InvalidOperationException if the outer function is a dynamic function and the inner function is a static function.
+
 ## 1.4.0 (2023-11-28)
 ### Summary
 This release contains an addition to the validation introduced in 1.3.0.


### PR DESCRIPTION
Fixes #42, in which nested functions could cause a InvalidOperationException. The issue affected dynamic functions containing static functions:

> We're counting arguments in case of dynamic functions, since they can have an arbitrary amount of arguments. Since the count is pretty much as cheap as repeated checks if we're handling a dynamic function, we're always counting, but we only use the result in case of a dynamic function.
> 
> Unfortunately, we were missing the pop in case of a static function, so if we have a static function nested inside of a dynamic function, we were looking at the wrong value.
> 
> This change always pops the count and thus fixes this issue.
> 
> We could think about introducing a dedicated function type for dynamic functions and separating the handling of dynamic and static functions. But this might also introduce more complexity and/or duplication into the code, so we should consider this carefully.
> 
> This is not an ugly fix, so we can accept it as solution for now.
