### PR TITLE
Public BuildAbstractSyntaxTree

### DIFF
--- a/Adletec.Sonic/Evaluator.cs
+++ b/Adletec.Sonic/Evaluator.cs
@@ -153,7 +153,7 @@ namespace Adletec.Sonic
                 return result;
             }
 
-            Operation operation = BuildAbstractSyntaxTree(expression, ConstantRegistry, optimizerEnabled, validationEnabled);
+            Operation operation = BuildAbstractSyntaxTree(expression, optimizerEnabled, validationEnabled);
             return BuildEvaluator(expression, operation);
         }
 
@@ -163,7 +163,7 @@ namespace Adletec.Sonic
         /// <param name="expression">The expression to check.</param>
         public void Validate(string expression)
         {
-            BuildAbstractSyntaxTree(expression, ConstantRegistry, false, true);
+            BuildAbstractSyntaxTree(expression, false, true);
         }
         
         /// <summary>
@@ -175,7 +175,7 @@ namespace Adletec.Sonic
         /// <param name="variables">The defined variable names.</param>
         public void Validate(string expression, IList<string> variables)
         {
-            var ast = BuildAbstractSyntaxTree(expression, ConstantRegistry, optimizerEnabled, true);
+            var ast = BuildAbstractSyntaxTree(expression, optimizerEnabled, true);
             variableValidator.Validate(ast, variables);
         }
 
@@ -235,7 +235,7 @@ namespace Adletec.Sonic
         /// <param name="optimize">If the abstract syntax tree should be optimized.</param>
         /// <param name="validate">If the expression should be checked for syntax errors.</param>
         /// <returns>The abstract syntax tree of the expression.</returns>
-        private Operation BuildAbstractSyntaxTree(string expression, IConstantRegistry compiledConstants, bool optimize, bool validate)
+        private Operation BuildAbstractSyntaxTree(string expression, bool optimize, bool validate)
         {
             List<Token> tokens = tokenReader.Read(expression);
             if (validate)
@@ -243,11 +243,11 @@ namespace Adletec.Sonic
                 expressionValidator.Validate(tokens, expression);
             }
             
-            var astBuilder = new AstBuilder(FunctionRegistry, compiledConstants);
+            var astBuilder = new AstBuilder(FunctionRegistry, ConstantRegistry);
             Operation operation = astBuilder.Build(tokens);
 
             return optimize
-                ? optimizer.Optimize(operation, this.FunctionRegistry, this.ConstantRegistry)
+                ? optimizer.Optimize(operation, FunctionRegistry, ConstantRegistry)
                 : operation;
         }
         

--- a/Adletec.Sonic/Evaluator.cs
+++ b/Adletec.Sonic/Evaluator.cs
@@ -231,6 +231,23 @@ namespace Adletec.Sonic
         /// be first tokenized.
         /// </summary>
         /// <param name="expression">A string containing the mathematical expression to be parsed.</param>
+        /// <returns>The abstract syntax tree of the expression.</returns>
+        public Operation BuildAbstractSyntaxTree(string expression)
+        {
+            if (string.IsNullOrEmpty(expression))
+                throw new ArgumentNullException(nameof(expression));
+
+            return BuildAbstractSyntaxTree(
+                expression,
+                optimizerEnabled,
+                validationEnabled);
+        }
+
+        /// <summary>
+        /// Build the abstract syntax tree for a given formula. The formula string will
+        /// be first tokenized.
+        /// </summary>
+        /// <param name="expression">A string containing the mathematical expression to be parsed.</param>
         /// <param name="compiledConstants">The constants which are to be available in the given formula.</param>
         /// <param name="optimize">If the abstract syntax tree should be optimized.</param>
         /// <param name="validate">If the expression should be checked for syntax errors.</param>

--- a/Adletec.Sonic/IEvaluator.cs
+++ b/Adletec.Sonic/IEvaluator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Adletec.Sonic.Execution;
+using Adletec.Sonic.Operations;
 
 namespace Adletec.Sonic
 {
@@ -90,5 +91,13 @@ namespace Adletec.Sonic
         /// <exception cref="MissingOperandParseException">If a binary operation is missing an operand.</exception>
         /// <exception cref="VariableNotDefinedException">If a variable necessary for evaluation is missing.</exception>
         void Validate(string expression, IList<string> variables);
+
+        /// <summary>
+        /// Build the abstract syntax tree for a given formula. The formula string will
+        /// be first tokenized.
+        /// </summary>
+        /// <param name="expression">A string containing the mathematical expression to be parsed.</param>
+        /// <returns>The abstract syntax tree of the expression.</returns>
+        Operation BuildAbstractSyntaxTree(string expression);
     }
 }


### PR DESCRIPTION
This the corresponding PR for issue #46.

Cleaned up the private BuildAbstractSyntaxTree method to be consistent with the rest of the code.

Added a public method that calls the private method and added it to the interface.