### PR TITLE
Experiment/45 Add quoted token input

### DIFF
--- a/Adletec.Sonic.Benchmark/Adletec.Sonic.Benchmark.csproj
+++ b/Adletec.Sonic.Benchmark/Adletec.Sonic.Benchmark.csproj
@@ -10,10 +10,11 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Adletec.Sonic.Benchmark</RootNamespace>
+        <LangVersion>12</LangVersion>
     </PropertyGroup>
 
 </Project>

--- a/Adletec.Sonic.DemoApp/Adletec.Sonic.DemoApp.csproj
+++ b/Adletec.Sonic.DemoApp/Adletec.Sonic.DemoApp.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Adletec.Sonic.DemoApp</AssemblyName>
         <RootNamespace>Adletec.Sonic.DemoApp</RootNamespace>
+        <LangVersion>12</LangVersion>
     </PropertyGroup>
 
 

--- a/Adletec.Sonic.Tests/Adletec.Sonic.Tests.csproj
+++ b/Adletec.Sonic.Tests/Adletec.Sonic.Tests.csproj
@@ -1,13 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
     <AssemblyName>Adletec.Sonic.Tests</AssemblyName>
 
     <RootNamespace>Adletec.Sonic.Tests</RootNamespace>
+
+    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Adletec.Sonic.Tests/EvaluatorTests.cs
+++ b/Adletec.Sonic.Tests/EvaluatorTests.cs
@@ -1731,6 +1731,22 @@ public class EvaluatorTests
         // assert "does not throw an exception"
         Assert.IsTrue(true);
     }
+    
+    // Issue #45
+    [TestMethod]
+    public void TestQuotedStringExpression()
+    {
+        var engine = SonicBuilders.Interpreted()
+            .AddFunction("'!@#$%^&*()_-+=[] {}|\\;:,.<>/?'", () => 4)
+            .AddConstant("'bar baz'", 5)
+            .Build();
+        
+        var expression = "'foo bar' + '!@#$%^&*()_-+=[] {}|\\;:,.<>/?'() + 'bar baz'";
+        var variables = new Dictionary<string, double> { {"'foo bar'", 3} };
+        
+        var result = engine.Evaluate(expression, variables);
+        Assert.AreEqual(12, result);
+    }
 }
 
 internal static class SonicEngines

--- a/Adletec.Sonic.Tests/EvaluatorTests.cs
+++ b/Adletec.Sonic.Tests/EvaluatorTests.cs
@@ -1718,7 +1718,7 @@ public class EvaluatorTests
             engine.Validate(expression, variables)
         );
     }
-    
+
     // Issue #42
     [TestMethod]
     public void TestStaticFuncInDynamicFunc()
@@ -1727,23 +1727,39 @@ public class EvaluatorTests
         var expression = "min(if(a==1, 2, 3))";
         var variables = new List<string> { "a" };
         engine.Validate(expression, variables);
-        
+
         // assert "does not throw an exception"
         Assert.IsTrue(true);
     }
-    
+
     // Issue #45
     [TestMethod]
     public void TestQuotedStringExpression()
     {
         var engine = SonicBuilders.Interpreted()
-            .AddFunction("'!@#$%^&*()_-+=[] {}|\\;:,.<>/?'", () => 4)
-            .AddConstant("'bar baz'", 5)
+            .AddFunction("!@#$%^&*()_-+=[] {}|\\;:,.<>/?", () => 4)
+            .AddConstant("bar baz", 5)
             .Build();
-        
+
         var expression = "'foo bar' + '!@#$%^&*()_-+=[] {}|\\;:,.<>/?'() + 'bar baz'";
-        var variables = new Dictionary<string, double> { {"'foo bar'", 3} };
-        
+        var variables = new Dictionary<string, double> { { "foo bar", 3 } };
+
+        var result = engine.Evaluate(expression, variables);
+        Assert.AreEqual(12, result);
+    }
+
+    [TestMethod]
+    public void TestQuotedAndUnquotedStringExpression()
+    {
+        // Validate that 
+        var engine = SonicBuilders.Interpreted()
+            .AddFunction("a", () => 4)
+            .AddConstant("b", 5)
+            .Build();
+
+        var expression = "'a'() + 'b' + 'c'";
+        var variables = new Dictionary<string, double> { { "c", 3 } };
+
         var result = engine.Evaluate(expression, variables);
         Assert.AreEqual(12, result);
     }

--- a/Adletec.Sonic.Tests/TokenReaderTests.cs
+++ b/Adletec.Sonic.Tests/TokenReaderTests.cs
@@ -771,7 +771,7 @@ public class TokenReaderTests
         Assert.AreEqual(5, tokens.Count);
 
         Assert.AreEqual(TokenType.Symbol, tokens[0].TokenType);
-        Assert.AreEqual("'foo bar baz'", tokens[0].Value);
+        Assert.AreEqual("foo bar baz", tokens[0].Value);
         Assert.AreEqual(0, tokens[0].StartPosition);
         Assert.AreEqual(13, tokens[0].Length);
 
@@ -779,7 +779,7 @@ public class TokenReaderTests
         Assert.AreEqual(14, tokens[1].StartPosition);
         Assert.AreEqual(1, tokens[1].Length);
 
-        Assert.AreEqual("'foobar baz'", tokens[2].Value);
+        Assert.AreEqual("foobar baz", tokens[2].Value);
         Assert.AreEqual(TokenType.Function, tokens[2].TokenType);
         Assert.AreEqual(16, tokens[2].StartPosition);
         Assert.AreEqual(12, tokens[2].Length);

--- a/Adletec.Sonic.Tests/TokenReaderTests.cs
+++ b/Adletec.Sonic.Tests/TokenReaderTests.cs
@@ -797,8 +797,16 @@ public class TokenReaderTests
     public void TestMissingQuoteInQuotedStringVariableName()
     {
         TokenReader reader = new TokenReader();
-        Assert.ThrowsException<MissingQuoteParseException>(() =>
-            reader.Read("'foo bar baz' + 'foobar baz()")
-        );
+        try
+        {
+            reader.Read("'foo bar baz' + 'foobar baz()");
+
+        }
+        catch (MissingQuoteParseException e)
+        {
+            Assert.AreEqual(16, e.QuotePosition);
+            return;
+        }
+        Assert.Fail("Expected MissingQuoteParseException");
     }
 }

--- a/Adletec.Sonic.Tests/TokenReaderTests.cs
+++ b/Adletec.Sonic.Tests/TokenReaderTests.cs
@@ -54,15 +54,15 @@ public class TokenReaderTests
         Assert.AreEqual(42, tokens[1].Value);
         Assert.AreEqual(1, tokens[1].StartPosition);
         Assert.AreEqual(2, tokens[1].Length);
-            
+
         Assert.AreEqual('+', tokens[2].Value);
         Assert.AreEqual(3, tokens[2].StartPosition);
         Assert.AreEqual(1, tokens[2].Length);
-            
+
         Assert.AreEqual(31, tokens[3].Value);
         Assert.AreEqual(4, tokens[3].StartPosition);
         Assert.AreEqual(2, tokens[3].Length);
-            
+
         Assert.AreEqual(')', tokens[4].Value);
         Assert.AreEqual(6, tokens[4].StartPosition);
         Assert.AreEqual(1, tokens[4].Length);
@@ -100,7 +100,7 @@ public class TokenReaderTests
         List<Token> tokens = reader.Read("(42+ 8) *2");
 
         Assert.AreEqual(7, tokens.Count);
-            
+
         Assert.AreEqual('(', tokens[0].Value);
         Assert.AreEqual(0, tokens[0].StartPosition);
         Assert.AreEqual(1, tokens[0].Length);
@@ -141,7 +141,7 @@ public class TokenReaderTests
         Assert.AreEqual('(', tokens[0].Value);
         Assert.AreEqual(0, tokens[0].StartPosition);
         Assert.AreEqual(1, tokens[0].Length);
-            
+
         Assert.AreEqual(42.87, tokens[1].Value);
         Assert.AreEqual(1, tokens[1].StartPosition);
         Assert.AreEqual(5, tokens[1].Length);
@@ -200,7 +200,7 @@ public class TokenReaderTests
         List<Token> tokens = reader.Read("varb(");
 
         Assert.AreEqual(2, tokens.Count);
-            
+
         Assert.AreEqual("varb", tokens[0].Value);
         Assert.AreEqual(0, tokens[0].StartPosition);
         Assert.AreEqual(4, tokens[0].Length);
@@ -284,7 +284,7 @@ public class TokenReaderTests
         Assert.AreEqual('_', tokens[0].Value);
         Assert.AreEqual(0, tokens[0].StartPosition);
         Assert.AreEqual(1, tokens[0].Length);
-        
+
         Assert.AreEqual(2.1, tokens[1].Value);
         Assert.AreEqual(1, tokens[1].StartPosition);
         Assert.AreEqual(3, tokens[1].Length);
@@ -326,7 +326,7 @@ public class TokenReaderTests
         Assert.AreEqual('*', tokens[1].Value);
         Assert.AreEqual(1, tokens[1].StartPosition);
         Assert.AreEqual(1, tokens[1].Length);
-        
+
         Assert.AreEqual('_', tokens[2].Value);
         Assert.AreEqual(2, tokens[2].StartPosition);
         Assert.AreEqual(1, tokens[2].Length);
@@ -359,7 +359,7 @@ public class TokenReaderTests
         Assert.AreEqual('_', tokens[3].Value);
         Assert.AreEqual(3, tokens[3].StartPosition);
         Assert.AreEqual(1, tokens[3].Length);
-        
+
         Assert.AreEqual(2, tokens[4].Value);
         Assert.AreEqual(4, tokens[4].StartPosition);
         Assert.AreEqual(1, tokens[4].Length);
@@ -484,7 +484,7 @@ public class TokenReaderTests
         List<Token> tokens = reader.Read("2.11E-3");
 
         Assert.AreEqual(1, tokens.Count);
-            
+
         Assert.AreEqual(2.11E-3, tokens[0].Value);
         Assert.AreEqual(0, tokens[0].StartPosition);
         Assert.AreEqual(7, tokens[0].Length);
@@ -623,6 +623,7 @@ public class TokenReaderTests
         Assert.AreEqual(5, tokens[5].StartPosition);
         Assert.AreEqual(1, tokens[5].Length);
     }
+
     [TestMethod]
     public void TestTokenReader28()
     {
@@ -721,7 +722,7 @@ public class TokenReaderTests
         Assert.AreEqual(2, tokens[2].StartPosition);
         Assert.AreEqual(1, tokens[2].Length);
     }
-    
+
     [TestMethod]
     public void TestTokenReader35()
     {
@@ -751,7 +752,7 @@ public class TokenReaderTests
             List<Token> tokens = reader.Read("3e");
         });
     }
-    
+
     [TestMethod]
     public void TestArgumentSeparatorCollidesWithDecimalSeparator()
     {
@@ -760,7 +761,7 @@ public class TokenReaderTests
             var _ = new TokenReader(CultureInfo.GetCultureInfo("de-DE"), ',');
         });
     }
-    
+
     [TestMethod]
     public void TestQuotedStringVariableName()
     {
@@ -782,15 +783,22 @@ public class TokenReaderTests
         Assert.AreEqual(TokenType.Function, tokens[2].TokenType);
         Assert.AreEqual(16, tokens[2].StartPosition);
         Assert.AreEqual(12, tokens[2].Length);
-        
+
         Assert.AreEqual(TokenType.LeftParenthesis, tokens[3].TokenType);
         Assert.AreEqual(28, tokens[3].StartPosition);
         Assert.AreEqual(1, tokens[3].Length);
-        
+
         Assert.AreEqual(TokenType.RightParenthesis, tokens[4].TokenType);
         Assert.AreEqual(29, tokens[4].StartPosition);
         Assert.AreEqual(1, tokens[4].Length);
     }
 
-    
+    [TestMethod]
+    public void TestMissingQuoteInQuotedStringVariableName()
+    {
+        TokenReader reader = new TokenReader();
+        Assert.ThrowsException<MissingQuoteParseException>(() =>
+            reader.Read("'foo bar baz' + 'foobar baz()")
+        );
+    }
 }

--- a/Adletec.Sonic.Tests/TokenReaderTests.cs
+++ b/Adletec.Sonic.Tests/TokenReaderTests.cs
@@ -721,7 +721,7 @@ public class TokenReaderTests
         Assert.AreEqual(2, tokens[2].StartPosition);
         Assert.AreEqual(1, tokens[2].Length);
     }
-
+    
     [TestMethod]
     public void TestTokenReader35()
     {
@@ -760,5 +760,37 @@ public class TokenReaderTests
             var _ = new TokenReader(CultureInfo.GetCultureInfo("de-DE"), ',');
         });
     }
+    
+    [TestMethod]
+    public void TestQuotedStringVariableName()
+    {
+        TokenReader reader = new TokenReader();
+        List<Token> tokens = reader.Read("'foo bar baz' + 'foobar baz'()");
+
+        Assert.AreEqual(5, tokens.Count);
+
+        Assert.AreEqual(TokenType.Symbol, tokens[0].TokenType);
+        Assert.AreEqual("'foo bar baz'", tokens[0].Value);
+        Assert.AreEqual(0, tokens[0].StartPosition);
+        Assert.AreEqual(13, tokens[0].Length);
+
+        Assert.AreEqual('+', tokens[1].Value);
+        Assert.AreEqual(14, tokens[1].StartPosition);
+        Assert.AreEqual(1, tokens[1].Length);
+
+        Assert.AreEqual("'foobar baz'", tokens[2].Value);
+        Assert.AreEqual(TokenType.Function, tokens[2].TokenType);
+        Assert.AreEqual(16, tokens[2].StartPosition);
+        Assert.AreEqual(12, tokens[2].Length);
+        
+        Assert.AreEqual(TokenType.LeftParenthesis, tokens[3].TokenType);
+        Assert.AreEqual(28, tokens[3].StartPosition);
+        Assert.AreEqual(1, tokens[3].Length);
+        
+        Assert.AreEqual(TokenType.RightParenthesis, tokens[4].TokenType);
+        Assert.AreEqual(29, tokens[4].StartPosition);
+        Assert.AreEqual(1, tokens[4].Length);
+    }
+
     
 }

--- a/Adletec.Sonic/ParseException.cs
+++ b/Adletec.Sonic/ParseException.cs
@@ -123,4 +123,18 @@ namespace Adletec.Sonic
             Operator = @operator;
         }
     }
+    
+    /// <summary>
+    /// This exception is thrown if there is no corresponding "'" for another "'" encountered during parsing.
+    /// </summary>
+    public class MissingQuoteParseException : ParseException
+    {
+        public int QuotePosition { get; }
+
+        public MissingQuoteParseException(string message, string expression, int quotePosition)
+            : base(message, expression)
+        {
+            QuotePosition = quotePosition;
+        }
+    }
 }

--- a/Adletec.Sonic/Parsing/Token.cs
+++ b/Adletec.Sonic/Parsing/Token.cs
@@ -6,12 +6,12 @@
     public struct Token
     {
         /// <summary>
-        /// The start position of the token in the input function text.
+        /// The start position of the token in the input function text. For quoted tokens (e.g.'foo bar' in "a + 'foo bar'"), this is the position of the opening quote.
         /// </summary>
         public int StartPosition;
-        
+
         /// <summary>
-        /// The length of token in the input function text.
+        /// The length of token in the input function text. For quoted tokens (e.g.'foo bar' in "a + 'foo bar'"), this is the length of the token _including_ the opening and closing quotes.
         /// </summary>
         public int Length;
 
@@ -21,7 +21,7 @@
         public TokenType TokenType;
 
         /// <summary>
-        /// The value of the token.
+        /// The value of the token. For quoted tokens (e.g.'foo bar' in "a + 'foo bar'"), this is the token _without_ the opening and closing quotes. This is so quoted and unquoted tokens evaluate to the same value (variable, constant, function).
         /// </summary>
         public object Value;
     }

--- a/Adletec.Sonic/Parsing/TokenReader.cs
+++ b/Adletec.Sonic/Parsing/TokenReader.cs
@@ -263,7 +263,7 @@ namespace Adletec.Sonic.Parsing
                                 nextCharIndex = i + 1;
                             }
                             if (nextCharIndex == characters.Length)
-                                throw new MissingQuoteParseException($"Missing corresponding quote to quote sign at position {i}.", expression, i);
+                                throw new MissingQuoteParseException($"Missing corresponding quote to quote sign at position {startPosition}.", expression, startPosition);
 
                             // skip the closing quote
                             i++;

--- a/Adletec.Sonic/Parsing/TokenReader.cs
+++ b/Adletec.Sonic/Parsing/TokenReader.cs
@@ -252,21 +252,23 @@ namespace Adletec.Sonic.Parsing
                                 throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", expression, i, characters[i].ToString());
                             break;
                         case '\'':
-                            var buffer = "'";
+                            var buffer = "";
                             var startPosition = i;
 
                             var nextCharIndex = i + 1;
-                            while (nextCharIndex < characters.Length)
+                            while (nextCharIndex < characters.Length && characters[nextCharIndex] != '\'')
                             {
                                 buffer += characters[++i];
                                 nextCharIndex = i + 1;
-                                if (characters[i] == '\'') break;
                             }
-                            if (nextCharIndex == characters.Length && characters[i] != '\'')
+                            if (nextCharIndex == characters.Length)
                                 throw new MissingQuoteParseException($"Missing corresponding quote to quote sign at position {i}.", expression, i);
 
-                            // exclusive end (the first char after the token)
-                            var textTokenEnd = nextCharIndex;
+                            // skip the closing quote
+                            i++;
+                            
+                            // exclusive end (the first char after the token and its closing quote)
+                            var textTokenEnd = ++nextCharIndex;
 
                             // Find next non-whitespace character index, so we can check if it is an opening parenthesis
                             // which would make our text token to a function.
@@ -297,7 +299,7 @@ namespace Adletec.Sonic.Parsing
 
             return tokens;
         }
-
+        
         private bool IsPartOfNumeric(char character, bool isFirstCharacter, bool afterMinus, bool isFormulaSubPart)
         {
             return character == decimalSeparator || (character >= '0' && character <= '9') || (isFormulaSubPart && isFirstCharacter && character == '-') || (!isFirstCharacter && !afterMinus && character == 'e') || (!isFirstCharacter && character == 'E');

--- a/Adletec.Sonic/Parsing/TokenReader.cs
+++ b/Adletec.Sonic/Parsing/TokenReader.cs
@@ -258,6 +258,7 @@ namespace Adletec.Sonic.Parsing
                             var nextCharIndex = i + 1;
                             while (nextCharIndex < characters.Length && characters[nextCharIndex] != '\'')
                             {
+                                // skip the opening quote
                                 buffer += characters[++i];
                                 nextCharIndex = i + 1;
                             }

--- a/Adletec.Sonic/Parsing/TokenReader.cs
+++ b/Adletec.Sonic/Parsing/TokenReader.cs
@@ -263,7 +263,7 @@ namespace Adletec.Sonic.Parsing
                                 if (characters[i] == '\'') break;
                             }
                             if (nextCharIndex == characters.Length && characters[i] != '\'')
-                                throw new InvalidTokenParseException($"Invalid token \"{characters[i]}\" detected at position {i}.", expression, i, characters[i].ToString());
+                                throw new MissingQuoteParseException($"Missing corresponding quote to quote sign at position {i}.", expression, i);
 
                             // exclusive end (the first char after the token)
                             var textTokenEnd = nextCharIndex;

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ double result = engine.Evaluate(expression, variables); // 3.4
 
 > [!CAUTION]
 > You might want to use this feature to allow the usage of arbitrary token names from external sources in your application, e.g. from user input. Be aware that _sonic_ won't sanitize the input or token names in any way. This means that defining an expression with user defined token names (e.g. `var expression = $"1234 + '{tokenFromUserInput}'";`) will allow the user to inject arbitrary code into your expression.
+>
 > In other words, **don't use user input as token names, if you don't want them to manipulate your expression**.
 
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,31 @@ If you intend to evaluate the same expression repeatedly with different variable
 avoid the overhead of retrieving the delegate from the cache, based on the expression string. On the other hand, there
 is no performance benefit in using this method if you are only evaluating the expression once.
 
+#### Handling Spaces and Special Characters
+
+_sonic_ expects expressions to contain alpha-numeric characters and mathematical operators only.
+
+However, it's possible to use single quotes (`'`) to wrap any symbol or function name, which will allow you to use arbitrary characters, including spaces, emojis, and even mathematical operators as part of your token name. 
+
+> [!NOTE]
+> There is no escaping mechanism for single quotes, i.e. you can't use single quotes in your token names.
+> Apart from that, everything inside the single quotes will be treated as a black box, so every valid string is a valid token name.
+
+Be aware that the quotation is not part of the token name, so `sin('x')` and `sin(x)` are equivalent. This also means that it's only necessary to use single quotes in the expression, not in the variable dictionary.
+
+```csharp
+var expression = "sin('x') + 'my variable'";
+Dictionary<string, double> variables = new Dictionary<string, double>();
+variables.Add("x", 0);
+variables.Add("my variable", 3.4);
+double result = engine.Evaluate(expression, variables); // 3.4
+```
+
+> [!CAUTION]
+> You might want to use this feature to allow the usage of arbitrary token names from external sources in your application, e.g. from user input. Be aware that _sonic_ won't sanitize the input or token names in any way. This means that defining an expression with user defined token names (e.g. `var expression = $"1234 + '{tokenFromUserInput}'";`) will allow the user to inject arbitrary code into your expression.
+> In other words, **don't use user input as token names, if you don't want them to manipulate your expression**.
+
+
 ### Using Mathematical Functions
 
 You can also use mathematical functions in your expressions:

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
+  }
+}


### PR DESCRIPTION
This change lets users use token quotation in order to process token names including spaces, special or reserved characters.

You can use quoted symbol (and function) names by using single quotes (') like that:

```csharp
var evaluator = Evaluator.CreateWithDefaults();

// use single quotes inside string
var expression = "2 + 'foo bar'";

// define variables, const, functions, etc. without single quotes
var variables =  new Dictionary<string, double> { { "foo bar", 3 } }

var result = evaluator.Evaluate(expression, variables);
```

This will allow you to use quoted and unquoted representations synonymically to refer to the same variables, constants, and functions. I.e.

```csharp
var expressionA = "'a' + b";

// and

var expressionB = "a + 'b'";

// are equivalent.
```